### PR TITLE
fix(select-item): add x as hotkey for select

### DIFF
--- a/src/multi-select.js
+++ b/src/multi-select.js
@@ -138,7 +138,7 @@ class MultiSelect extends PureComponent {
 			onHighlight(slicedItems[nextHighlightedIndex]);
 		}
 
-		if (s === SPACE) {
+		if (s === SPACE || s === 'x') {
 			const slicedItems = hasLimit ? arrRotate(items, rotateIndex).slice(0, limit) : items;
 			const selectedItem = slicedItems[highlightedIndex];
 			const selectedItemKey = selectedItem.key || selectedItem.value;


### PR DESCRIPTION
`x` is a common hotkey for "Select" so I thought it'd be nice to add this.