### PR TITLE
Make MultiSelect controlled

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 /**
  * Props for custom indicator component.
@@ -15,13 +15,13 @@ export type CheckBoxProps = { isSelected?: boolean };
  */
 export type ItemProps = {
 	isHighlighted?: boolean;
-	label: string
+	label: string;
 };
 
 /**
  * Select item definition.
  */
-export type Item = {
+export type ListedItem = {
 	label: string;
 	value: React.Key;
 	key?: React.Key;
@@ -29,9 +29,24 @@ export type Item = {
 
 export type SelectedItem = {
 	label?: string;
-	value: React.Key
+	value: React.Key;
 	key?: React.Key;
-}
+};
+
+/**
+ * Default indicator component.
+ */
+export class Indicator extends React.Component<IndicatorProps> {}
+
+/**
+ * Default check box component.
+ */
+export class CheckBox extends React.Component<CheckBoxProps> {}
+
+/**
+ * Default item component.
+ */
+export class Item extends React.Component<ItemProps> {}
 
 export type MultiSelectProps = {
 	/**
@@ -39,7 +54,7 @@ export type MultiSelectProps = {
 	 * it may also optionally have a `key` prop.
 	 * If no `key` prop is provided, `value` will be used as the item key.
 	 */
-	items?: Item[];
+	items?: ListedItem[];
 
 	/**
 	 * Items set as selected.
@@ -66,19 +81,19 @@ export type MultiSelectProps = {
 	 * Function to call when user selects an item.
 	 * Item object is passed to that function as an argument.
 	 */
-	onSelect?: (item: Item) => void;
+	onSelect?: (item: ListedItem) => void;
 
 	/**
 	 * Function to call when user unselects an item.
 	 * Item object is passed to that function as an argument.
 	 */
-	onUnselect?: (item: Item) => void;
+	onUnselect?: (item: ListedItem) => void;
 
 	/**
 	 * Function to call when user submits selected items.
 	 * Selected Item list is passed to that function as an argument.
 	 */
-	onSubmit?: (item: Item[]) => void;
+	onSubmit?: (item: ListedItem[]) => void;
 
 	/**
 	 * Custom component to override the default indicator component.

--- a/index.test-d.tsx
+++ b/index.test-d.tsx
@@ -1,13 +1,18 @@
-import * as React from 'react';
-import MultiSelect, {Item, IndicatorProps, ItemProps, CheckBoxProps} from '.';
+import * as React from "react";
+import MultiSelect, {
+	ListedItem,
+	IndicatorProps,
+	ItemProps,
+	CheckBoxProps
+} from ".";
 
-const items: Item[] = [
-	{label: 'label 1', value: 'label 1'},
-	{label: 'label 2', value: 'label 2'}
+const items: ListedItem[] = [
+	{ label: "label 1", value: "label 1" },
+	{ label: "label 2", value: "label 2" }
 ];
-const keyedItems: Item[] = [
-	{label: 'label 1', value: 'label 1', key: 1},
-	{label: 'label 2', value: 'label 2', key: 2}
+const keyedItems: ListedItem[] = [
+	{ label: "label 1", value: "label 1", key: 1 },
+	{ label: "label 2", value: "label 2", key: 2 }
 ];
 
 const plain = () => <MultiSelect />;
@@ -16,24 +21,24 @@ const withProps = () => <MultiSelect focus={false} limit={10} />;
 const selectWithItems = () => <MultiSelect items={items} />;
 const selectWithKeyedItems = () => <MultiSelect items={keyedItems} />;
 
-const onSelect = (item: Item) => console.log(item);
+const onSelect = (item: ListedItem) => console.log(item);
 const withSelectHandler = () => <MultiSelect onSelect={onSelect} />;
 
-const onUnselect = (item: Item) => console.log(item);
+const onUnselect = (item: ListedItem) => console.log(item);
 const withUnselectHandler = () => <MultiSelect onUnselect={onUnselect} />;
 
-const onSubmit = (items: Item[]) => console.log(items);
+const onSubmit = (items: ListedItem[]) => console.log(items);
 const withSubmitHandler = () => <MultiSelect onSubmit={onSubmit} />;
 
-const CustomIndikator: React.FC<IndicatorProps> = ({isHighlighted}) => (
-	<div>{isHighlighted ? '✓' : ''}</div>
+const CustomIndikator: React.FC<IndicatorProps> = ({ isHighlighted }) => (
+	<div>{isHighlighted ? "✓" : ""}</div>
 );
-const CustomCheckBox: React.FC<CheckBoxProps> = ({isSelected}) => (
-	<div>{isSelected ? '✓' : ''}</div>
+const CustomCheckBox: React.FC<CheckBoxProps> = ({ isSelected }) => (
+	<div>{isSelected ? "✓" : ""}</div>
 );
-const CustomItemComponent: React.FC<ItemProps> = ({isHighlighted, label}) => (
+const CustomItemComponent: React.FC<ItemProps> = ({ isHighlighted, label }) => (
 	<div>
-		{isHighlighted ? '✓' : ''} {label}
+		{isHighlighted ? "✓" : ""} {label}
 	</div>
 );
 const overrideComponents = () => (

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 		],
 		"rules": {
 			"react/no-unused-prop-types": 1,
-			"unicorn/no-hex-escape": 0
+			"unicorn/no-hex-escape": 0,
+			"eslint-comments/no-unused-disable": 0
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"prop-types": "^15.5.10"
 	},
 	"devDependencies": {
+		"@ava/babel-preset-stage-4": "^4.0.0",
 		"@babel/cli": "^7.2.3",
 		"@babel/core": "^7.3.3",
 		"@babel/plugin-proposal-class-properties": "^7.3.3",

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,20 @@ Default: `[]`
 Items to display in a list. Each item must be an object and have `label` and `value` props, it may also optionally have a `key` prop.
 If no `key` prop is provided, `value` will be used as the item key.
 
+### selected
+
+Type: `array`<br>
+Default: `undefined`
+
+List of the selected items. If `undefined`, the component will be **uncontrolled** and will store internally selected items.
+
+### defaultSelected
+
+Type: `array`<br>
+Default: `[]`
+
+List of initial selected items (this works only when `selected` is `undefined`).
+
 ### focus
 
 Type: `boolean`<br>

--- a/src/multi-select.js
+++ b/src/multi-select.js
@@ -132,7 +132,8 @@ class MultiSelect extends PureComponent {
 
 	handleInput = data => {
 		const {items, focus, onHighlight, onSubmit} = this.props;
-		const {rotateIndex, highlightedIndex, selected} = this.state;
+		const {rotateIndex, highlightedIndex} = this.state;
+		const selected = this.props.selected || this.state.selected;
 		const {limit, hasLimit} = this;
 
 		if (focus === false) {

--- a/src/multi-select.js
+++ b/src/multi-select.js
@@ -26,7 +26,9 @@ class MultiSelect extends PureComponent {
 		onSelect: PropTypes.func,
 		onUnselect: PropTypes.func,
 		onSubmit: PropTypes.func,
-		onHighlight: PropTypes.func
+		onHighlight: PropTypes.func,
+		stdin: PropTypes.any.isRequired,
+		setRawMode: PropTypes.func.isRequired
 	}
 
 	static defaultProps = {

--- a/src/multi-select.js
+++ b/src/multi-select.js
@@ -33,7 +33,7 @@ class MultiSelect extends PureComponent {
 
 	static defaultProps = {
 		items: [],
-		selected: [],
+		selected: undefined,
 		defaultSelected: [],
 		focus: true,
 		initialIndex: 0,
@@ -50,7 +50,7 @@ class MultiSelect extends PureComponent {
 	state = {
 		rotateIndex: 0,
 		highlightedIndex: this.props.initialIndex,
-		selected: this.props.selected.length === 0 ? this.props.defaultSelected : this.props.selected
+		selected: this.props.selected || this.props.defaultSelected
 	}
 
 	render() {
@@ -100,16 +100,10 @@ class MultiSelect extends PureComponent {
 				highlightedIndex: 0
 			});
 		}
-
-		if (!isEqual(prevProps.selected, this.props.selected)) {
-			this.setState({ // eslint-disable-line react/no-did-update-set-state
-				selected: prevProps.selected
-			});
-		}
 	}
 
 	isSelected(value) {
-		const {selected} = this.state;
+		const selected = this.props.selected || this.state.selected;
 
 		return selected.map(({value}) => value).includes(
 			value
@@ -118,7 +112,7 @@ class MultiSelect extends PureComponent {
 
 	selectItem(item) {
 		const {onSelect, onUnselect} = this.props;
-		const {selected} = this.state;
+		const selected = this.props.selected || this.state.selected;
 
 		if (this.isSelected(item.value)) {
 			onUnselect(item);


### PR DESCRIPTION
The prop `selected` should be optional with default value `undefined`. This allows the component to be controlled: when the prop is `undefined` the component uses its internal state to manage the selected items. Otherwise, when the selected prop is an array, even if it's empty, it should represent what the user sees. So

```js
const selected = this.props.selected || this.state.selected;
``` 
should make `MultiSelect` controlled.